### PR TITLE
Fix week range and typo in time tracking

### DIFF
--- a/packages/server/controllers/timeTrack.controller.ts
+++ b/packages/server/controllers/timeTrack.controller.ts
@@ -39,7 +39,7 @@ export class TimeTrackController {
     }
   };
 
-  getRecoringStateAsync = async (
+  getRecordingStateAsync = async (
     req: Request,
     res: Response,
     next: NextFunction,

--- a/packages/server/routes/timeTrack.router.ts
+++ b/packages/server/routes/timeTrack.router.ts
@@ -5,7 +5,7 @@ const router = express.Router();
 const timeTrackController = new TimeTrackController();
 
 router.get("/", timeTrackController.getTimeTrackEntriesAsync);
-router.get("/recording", timeTrackController.getRecoringStateAsync);
+router.get("/recording", timeTrackController.getRecordingStateAsync);
 router.put("/recording", timeTrackController.toggleRecordingAsync);
 router.put("/:id", timeTrackController.updateTimeTrackEntryAsync);
 

--- a/packages/server/services/timeTrack.service.ts
+++ b/packages/server/services/timeTrack.service.ts
@@ -61,10 +61,11 @@ class TimeTrackService extends BaseService<ITimeTrackEntry> {
 
   public async getTimetrackEntriesAsync(): Promise<ITimeTrackEntry[]> {
     const startOfWeek = new Date();
+    startOfWeek.setHours(0, 0, 0, 0);
     startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay());
 
-    const endOfWeek = new Date();
-    endOfWeek.setDate(startOfWeek.getDate() + 6);
+    const endOfWeek = new Date(startOfWeek);
+    endOfWeek.setDate(endOfWeek.getDate() + 7);
 
     return this.repository.getAllAsync({
       start: { $gte: startOfWeek, $lt: endOfWeek },


### PR DESCRIPTION
## Summary
- fix misspelled `getRecordingStateAsync` controller method
- use new method name in router
- ensure weekly timetrack query covers full week

## Testing
- `npx tsc -p packages/server/tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'bun-types')*

------
https://chatgpt.com/codex/tasks/task_e_6840120e6d0c8330a56cd94dc2afd94e