### PR TITLE
Implement branch name fallback modal

### DIFF
--- a/packages/client/src/components/modals/BranchNameModal/BranchNameModal.module.css
+++ b/packages/client/src/components/modals/BranchNameModal/BranchNameModal.module.css
@@ -1,0 +1,6 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  width: 400px;
+}

--- a/packages/client/src/components/modals/BranchNameModal/BranchNameModal.tsx
+++ b/packages/client/src/components/modals/BranchNameModal/BranchNameModal.tsx
@@ -1,3 +1,28 @@
+  const validBranchName = (name: string) => {
+    return /^[A-Za-z0-9._-]+$/.test(name) && name.trim().length > 0;
+  };
+
+    if (!issueId) {
+      addNotification({
+        title: "Error",
+        description: "No issue selected",
+        type: "error",
+      });
+      return;
+    }
+
+    if (!validBranchName(branchName())) {
+      addNotification({
+        title: "Error",
+        description: "Invalid branch name",
+        type: "error",
+      });
+      return;
+    }
+
+        <label for="branch-name">Branch name</label>
+          id="branch-name"
+          aria-label="Branch name"
 import { createSignal, onMount, type JSXElement } from "solid-js";
 import BaseModal, { type BaseModalProps } from "../BaseModal/BaseModal";
 import { closeModal, modalStore, ModalType } from "@client/stores/modalStore";

--- a/packages/client/src/components/modals/BranchNameModal/BranchNameModal.tsx
+++ b/packages/client/src/components/modals/BranchNameModal/BranchNameModal.tsx
@@ -1,0 +1,66 @@
+import { createSignal, onMount, type JSXElement } from "solid-js";
+import BaseModal, { type BaseModalProps } from "../BaseModal/BaseModal";
+import { closeModal, modalStore, ModalType } from "@client/stores/modalStore";
+import { createMergeRequestAndBranchAsync } from "@client/services/gitlabService";
+import { addNotification } from "@client/services/notificationService";
+import styles from "./BranchNameModal.module.css";
+
+interface BranchNameModalProps extends BaseModalProps {}
+
+const BranchNameModal = (props: BranchNameModalProps): JSXElement => {
+  const [branchName, setBranchName] = createSignal<string>("");
+  let inputRef: HTMLInputElement | null = null;
+
+  onMount(() => {
+    setTimeout(() => inputRef?.focus(), 0);
+  });
+
+  const handleSubmit = async () => {
+    const issueId = modalStore.selectedTask?.gitlabIid?.toString() || "";
+    try {
+      const { mergeRequest } = await createMergeRequestAndBranchAsync(
+        issueId,
+        branchName(),
+      );
+      addNotification({
+        title: "Branch and Merge request created",
+        description: `Created merge request ${mergeRequest.title}`,
+        type: "success",
+      });
+      closeModal(ModalType.BranchName);
+    } catch (error) {
+      addNotification({
+        title: "Error",
+        description: "Failed to create merge request",
+        type: "error",
+      });
+    }
+  };
+
+  return (
+    <BaseModal
+      {...props}
+      submitText="Create"
+      closeText="Cancel"
+      onSubmit={handleSubmit}
+      onClose={() => closeModal(ModalType.BranchName)}
+    >
+      <h2>Enter branch name</h2>
+      <div class={styles.form}>
+        <input
+          type="text"
+          ref={(el) => (inputRef = el)}
+          value={branchName()}
+          onInput={(e) => setBranchName(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSubmit();
+            else if (e.key === "Escape") closeModal(ModalType.BranchName);
+          }}
+          placeholder="Branch name"
+        />
+      </div>
+    </BaseModal>
+  );
+};
+
+export default BranchNameModal;

--- a/packages/client/src/components/modals/index.ts
+++ b/packages/client/src/components/modals/index.ts
@@ -2,5 +2,12 @@ import BaseModal from "./BaseModal/BaseModal";
 import HelpModal from "./HelpModal/HelpModal";
 import DeleteModal from "./DeleteModal/DeleteModal";
 import EditOrCreateTaskModal from "./EditOrCreateTaskModal/EditOrCreateTaskModal";
+import BranchNameModal from "./BranchNameModal/BranchNameModal";
 
-export { BaseModal, HelpModal, DeleteModal, EditOrCreateTaskModal };
+export {
+  BaseModal,
+  HelpModal,
+  DeleteModal,
+  EditOrCreateTaskModal,
+  BranchNameModal,
+};

--- a/packages/client/src/modules/KanbanBoard/KanbanBoard.tsx
+++ b/packages/client/src/modules/KanbanBoard/KanbanBoard.tsx
@@ -1,5 +1,9 @@
 import { createSignal, onMount, Show } from "solid-js";
-import { EditOrCreateTaskModal, DeleteModal } from "../../components/modals";
+import {
+  EditOrCreateTaskModal,
+  DeleteModal,
+  BranchNameModal,
+} from "../../components/modals";
 import TaskDetailsModal from "../../components/modals/TaskDetailsModal/TaskDetailsModal";
 import { STATES } from "../../constants";
 import { addNotification } from "../../services/notificationService";
@@ -121,6 +125,9 @@ const KanbanBoard = () => {
       )}
       {modalStore.activeModals.includes(ModalType.Reply) && (
         <ReplyModal onClose={handleCloseModal} />
+      )}
+      {modalStore.activeModals.includes(ModalType.BranchName) && (
+        <BranchNameModal onClose={handleCloseModal} />
       )}
       <div class={styles.kanban}>
         <Show

--- a/packages/client/src/services/gitlabService.ts
+++ b/packages/client/src/services/gitlabService.ts
@@ -181,9 +181,17 @@ export const createMergeRequestAndBranchForSelectedTaskAsync = async () => {
   const columnTasks = getColumnTasks();
   const task = columnTasks[keyboardNavigationStore.selectedTaskIndex];
   if (task.type === "issue") {
+    if (!task.gitlabIid) {
+      addNotification({
+        title: "Error",
+        description: "Issue does not have a GitLab IID",
+        type: "error",
+      });
+      return;
+    }
     try {
       const { mergeRequest } = await createMergeRequestAndBranchAsync(
-        task.gitlabIid?.toString() || "",
+        task.gitlabIid.toString(),
       );
       addNotification({
         title: "Branch and Merge request created",
@@ -238,6 +246,9 @@ export const createMergeRequestAndBranchAsync = async (
   issueId: string,
   branchName?: string,
 ) => {
+  if (!issueId) {
+    throw new Error("Missing issue ID");
+  }
   const res = await axios.post(`/git/create-merge-request`, {
     issueId,
     branchName,

--- a/packages/client/src/services/gitlabService.ts
+++ b/packages/client/src/services/gitlabService.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import { keyboardNavigationStore } from "../stores/keyboardNavigationStore";
 import { fetchTasksAsync, getColumnTasks } from "../stores/taskStore";
 import {
@@ -8,8 +8,9 @@ import {
   uiStore,
 } from "../stores/uiStore";
 import { addNotification } from "./notificationService";
+import { openBranchNameModal } from "./modalService";
 import { has } from "lodash";
-import type { IDiscussion } from "shared/types/task";
+import type { IDiscussion, ITask } from "shared/types/task";
 
 export const syncGitlabAsync = async () => {
   try {
@@ -178,18 +179,31 @@ export const openSelectedTaskLink = () => {
 
 export const createMergeRequestAndBranchForSelectedTaskAsync = async () => {
   const columnTasks = getColumnTasks();
-  if (columnTasks[keyboardNavigationStore.selectedTaskIndex].type === "issue") {
-    const { mergeRequest } = await createMergeRequestAndBranchAsync(
-      columnTasks[
-        keyboardNavigationStore.selectedTaskIndex
-      ].gitlabIid?.toString() || "",
-    );
-
-    addNotification({
-      title: "Branch and Merge request created",
-      description: `Created merge request ${mergeRequest.title}`,
-      type: "success",
-    });
+  const task = columnTasks[keyboardNavigationStore.selectedTaskIndex];
+  if (task.type === "issue") {
+    try {
+      const { mergeRequest } = await createMergeRequestAndBranchAsync(
+        task.gitlabIid?.toString() || "",
+      );
+      addNotification({
+        title: "Branch and Merge request created",
+        description: `Created merge request ${mergeRequest.title}`,
+        type: "success",
+      });
+    } catch (error: any) {
+      if (
+        error instanceof AxiosError &&
+        (error.response?.status === 400 || error.response?.status === 409)
+      ) {
+        openBranchNameModal(task as ITask);
+      } else {
+        addNotification({
+          title: "Error",
+          description: "Failed to create merge request",
+          type: "error",
+        });
+      }
+    }
   } else {
     addNotification({
       title: "Warning",
@@ -220,8 +234,14 @@ export const getGitLabUsersAsync = async () => {
   }
 };
 
-export const createMergeRequestAndBranchAsync = async (issueId: string) => {
-  const res = await axios.post(`/git/create-merge-request`, { issueId });
+export const createMergeRequestAndBranchAsync = async (
+  issueId: string,
+  branchName?: string,
+) => {
+  const res = await axios.post(`/git/create-merge-request`, {
+    issueId,
+    branchName,
+  });
 
   if (res.status !== 200) {
     throw new Error("Failed to create merge request");

--- a/packages/client/src/services/modalService.ts
+++ b/packages/client/src/services/modalService.ts
@@ -11,6 +11,7 @@ import {
 } from "../stores/modalStore";
 import { getColumnTasks } from "../stores/taskStore";
 import { timeTrackStore } from "../stores/timeTrackStore";
+import type { ITask } from "shared/types/task";
 
 export const openHelpModal = () => {
   openModal(ModalType.Help);
@@ -60,6 +61,11 @@ export const openPipelineModal = () => {
   );
 
   openModal(ModalType.Pipeline);
+};
+
+export const openBranchNameModal = (task: ITask) => {
+  setSelectedTaskForModal(task);
+  openModal(ModalType.BranchName);
 };
 
 export const getTopModal = () => {

--- a/packages/client/src/stores/modalStore.ts
+++ b/packages/client/src/stores/modalStore.ts
@@ -13,6 +13,7 @@ export enum ModalType {
   None = "",
   Pipeline = "pipeline",
   Reply = "reply",
+  BranchName = "branch-name",
 }
 
 export const [modalStore, setModalStore] = createStore({

--- a/packages/server/controllers/gitlab.controller.ts
+++ b/packages/server/controllers/gitlab.controller.ts
@@ -70,9 +70,9 @@ export class GitlabController {
     next: NextFunction,
   ): Promise<void> => {
     try {
-      const { issueId } = req.body;
+      const { issueId, branchName } = req.body;
       const result =
-        await this.gitlabService.createGitlabMergeRequestAsync(issueId);
+        await this.gitlabService.createGitlabMergeRequestAsync(issueId, branchName);
       res.status(200).json(result);
     } catch (error) {
       handleControllerError(error, next);

--- a/packages/server/services/gitlab.service.ts
+++ b/packages/server/services/gitlab.service.ts
@@ -9,6 +9,12 @@ import { UserService } from "@server/services/user.service";
 import SocketHandler from "@server/sockets";
 import { ContextKeys, getContext } from "@server/utils/asyncContext";
 import { fetchAllFromPaginatedApiAsync } from "@server/utils/fetchAllFromPaginatedApi";
+    if (!/^[A-Za-z0-9._-]+$/.test(desiredBranch)) {
+      throw new GitlabError("Invalid branch name", 400);
+    }
+    if (!branchName) {
+      throw new GitlabError("Invalid branch name", 400);
+    }
 import { transformNote } from "@server/utils/transformHelpers";
 import type { IDiscussion, ITask } from "shared/types/task";
 

--- a/packages/server/services/gitlab.service.ts
+++ b/packages/server/services/gitlab.service.ts
@@ -9,11 +9,7 @@ import { UserService } from "@server/services/user.service";
 import SocketHandler from "@server/sockets";
 import { ContextKeys, getContext } from "@server/utils/asyncContext";
 import { fetchAllFromPaginatedApiAsync } from "@server/utils/fetchAllFromPaginatedApi";
-import {
-  transformDiscussion,
-  transformNote,
-} from "@server/utils/transformHelpers";
-import type { IPagination } from "shared/types/pagination";
+import { transformNote } from "@server/utils/transformHelpers";
 import type { IDiscussion, ITask } from "shared/types/task";
 
 export class GitlabService {
@@ -22,7 +18,7 @@ export class GitlabService {
   private userService = new UserService();
   private gitlabClient = new GitlabClient();
 
-  async createGitlabMergeRequestAsync(issueId: string) {
+  async createGitlabMergeRequestAsync(issueId: string, branchName?: string) {
     const currentProject = getContext(ContextKeys.Project);
     if (!currentProject) throw new GitlabError("No project selected", 404);
 
@@ -31,7 +27,15 @@ export class GitlabService {
     });
     if (!issue) throw new GitlabError("Issue not found", 404);
 
-    await this.createBranch(currentProject.id, issue);
+    const desiredBranch = branchName ?? issue.gitlabIid!.toString();
+    try {
+      await this.createBranch(currentProject.id, desiredBranch);
+    } catch (e) {
+      if (!branchName && e instanceof MochiError) {
+        throw new MochiError("Branch creation failed", e.statusCode, e);
+      }
+      throw e;
+    }
 
     const user = await this.getUserByAccessTokenAsync();
     if (!user) throw new GitlabError("No current user found", 404);
@@ -40,6 +44,7 @@ export class GitlabService {
       currentProject.id,
       issue,
       user.gitlabId.toString(),
+      desiredBranch,
     );
 
     const newMergeRequestTaskResult = await this.taskEmitter.createTaskAsync(
@@ -71,45 +76,30 @@ export class GitlabService {
   }
 
   @ruleEvent(EventNamespaces.GitLab, EventTypes.CreateBranch)
-  private async createBranch(projectId: string, issue: ITask) {
-    try {
-      await this.gitlabClient.request({
-        endpoint: `/projects/${projectId}/repository/branches`,
-        method: "POST",
-        data: {
-          id: projectId,
-          branch: issue.gitlabIid,
-          ref: "develop",
-        },
-      });
-    } catch (e) {
-      if (e instanceof MochiError) {
-        await this.gitlabClient.request({
-          endpoint: `/projects/${projectId}/repository/branches`,
-          method: "POST",
-          data: {
-            id: projectId,
-            branch: "issue-" + issue.gitlabIid,
-            ref: "develop",
-          },
-        });
-      } else {
-        throw e;
-      }
-    }
+  private async createBranch(projectId: string, branchName: string) {
+    await this.gitlabClient.request({
+      endpoint: `/projects/${projectId}/repository/branches`,
+      method: "POST",
+      data: {
+        id: projectId,
+        branch: branchName,
+        ref: "develop",
+      },
+    });
   }
 
   private async createMergeRequest(
     projectId: string,
     issue: ITask,
     userId: string,
+    branchName: string,
   ) {
     return this.gitlabClient.request({
       endpoint: `/projects/${projectId}/merge_requests`,
       method: "POST",
       data: {
         id: projectId,
-        source_branch: issue.gitlabIid,
+        source_branch: branchName,
         target_branch: "develop",
         title: `Draft: Resolve "${issue.title}"`,
         description: `Closes #${issue.gitlabIid}`,


### PR DESCRIPTION
## Summary
- add BranchNameModal to prompt user for branch name when the default branch creation fails
- support new modal in Kanban board and modal service
- update GitLab services to accept branch names and remove automatic fallback
- handle branch creation errors on client and show modal
- extend API to allow passing branchName

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684013bd08e0833091f874f61d431d80