### PR TITLE
Add drag-and-drop for kanban tasks

### DIFF
--- a/packages/client/src/components/Kanban/TaskCard/TaskCard.module.css
+++ b/packages/client/src/components/Kanban/TaskCard/TaskCard.module.css
@@ -45,6 +45,13 @@
   cursor: pointer;
 }
 
+.dragging {
+  opacity: 0.6;
+  cursor: grabbing;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  user-select: none;
+}
+
 .selectedTask {
   border: 3px solid var(--color-peach) !important;
   background-color: rgba(255, 255, 255, 0.1);

--- a/packages/client/src/components/Kanban/TaskCard/TaskCard.tsx
+++ b/packages/client/src/components/Kanban/TaskCard/TaskCard.tsx
@@ -6,13 +6,17 @@ import styles from "./TaskCard.module.css";
 import xMasHat from "@client/assets/xmas.png";
 import dayjs from "dayjs";
 import { random } from "shared/utils/random";
+import { setDraggedTask } from "@client/stores/dragStore";
 
 interface TaskCardProps {
   task: Partial<ITask>;
   isSelected: boolean;
   onClick: () => void;
   taskIndex: number;
+  columnIndex: number;
   setTaskRef: (el: HTMLElement) => void;
+  onDragOver?: (e: DragEvent) => void;
+  onDrop?: (e: DragEvent) => void;
 }
 
 const TaskCard = (props: TaskCardProps) => {
@@ -50,6 +54,13 @@ const TaskCard = (props: TaskCardProps) => {
     <div
       onClick={props.onClick}
       ref={props.setTaskRef}
+      draggable
+      onDragOver={props.onDragOver}
+      onDrop={props.onDrop}
+      onDragStart={() => {
+        setDraggedTask(props.task._id as string, props.columnIndex);
+      }}
+      onDragEnd={() => setDraggedTask(null, null)}
       class={`${styles.task} ${props.isSelected ? styles.selectedTask : ""} ${
         props.task.custom ? styles.customTask : ""
       } ${props.task.deleted ? styles.deletedTask : ""} ${

--- a/packages/client/src/components/Kanban/TaskCard/TaskCard.tsx
+++ b/packages/client/src/components/Kanban/TaskCard/TaskCard.tsx
@@ -6,7 +6,7 @@ import styles from "./TaskCard.module.css";
 import xMasHat from "@client/assets/xmas.png";
 import dayjs from "dayjs";
 import { random } from "shared/utils/random";
-import { setDraggedTask } from "@client/stores/dragStore";
+import { dragStore, setDraggedTask } from "@client/stores/dragStore";
 
 interface TaskCardProps {
   task: Partial<ITask>;
@@ -65,9 +65,10 @@ const TaskCard = (props: TaskCardProps) => {
         props.task.custom ? styles.customTask : ""
       } ${props.task.deleted ? styles.deletedTask : ""} ${
         styles[props.task.type as string]
-      }`}
+      } ${dragStore.taskId === props.task._id ? styles.dragging : ""}`}
       style={{
         "view-transition-name": "card-" + props.task._id,
+        "user-select": dragStore.taskId === props.task._id ? "none" : "auto",
       }}
     >
       <p>{props.task.title}</p>

--- a/packages/client/src/stores/dragStore.ts
+++ b/packages/client/src/stores/dragStore.ts
@@ -1,0 +1,20 @@
+import { createStore } from "solid-js/store";
+
+interface DragState {
+  taskId: string | null;
+  fromColumnIndex: number | null;
+}
+
+export const [dragStore, setDragStore] = createStore<DragState>({
+  taskId: null,
+  fromColumnIndex: null,
+});
+
+export const setDraggedTask = (
+  taskId: string | null,
+  columnIndex: number | null = null,
+) => {
+  setDragStore("taskId", taskId);
+  setDragStore("fromColumnIndex", columnIndex);
+};
+


### PR DESCRIPTION
## Summary
- implement drag state store
- add drag handlers to TaskCard
- support drop handling in TaskColumn
- allow moving and reordering tasks via drag and drop

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'bun-types' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68402048a7508330a103346cb3b98520